### PR TITLE
hotfix: CSSの間違ったプロパティを削除

### DIFF
--- a/dist/wwa_message_loader.css
+++ b/dist/wwa_message_loader.css
@@ -11,7 +11,6 @@
 .search-box__type-label--object,
 .parts-item--object .parts-item__title {
   color: #c00000;
-  color:
 }
 
 .search-box__type-label--map,


### PR DESCRIPTION
CSSファイルになぜか残っていた `color` プロパティを削除します。